### PR TITLE
Fix reported bugs

### DIFF
--- a/apex-squid/src/main/java/org/fundacionjala/enforce/sonarqube/apex/api/ApexKeyword.java
+++ b/apex-squid/src/main/java/org/fundacionjala/enforce/sonarqube/apex/api/ApexKeyword.java
@@ -118,6 +118,7 @@ public enum ApexKeyword implements TokenType {
     VIRTUAL("virtual"),
     VOID("void"),
     VOLATILE("volatile"),
+    WEBSERVICE("webservice"),
     WHEN("when"),
     WHILE("while"),
     WITH("with"),

--- a/apex-squid/src/main/java/org/fundacionjala/enforce/sonarqube/apex/api/grammar/buildersource/MostUsed.java
+++ b/apex-squid/src/main/java/org/fundacionjala/enforce/sonarqube/apex/api/grammar/buildersource/MostUsed.java
@@ -64,7 +64,9 @@ public class MostUsed {
                         LAST,
                         CATEGORY,
                         NETWORK,
-                        ITERATOR));
+                        ITERATOR,
+                        COUNT,
+                        ORDER));
     }
 
     /**
@@ -112,6 +114,7 @@ public class MostUsed {
                         CHAR,
                         COLLECT,
                         CONST,
+                        COUNT,
                         DEFAULT,
                         END,
                         EXIT,
@@ -160,7 +163,8 @@ public class MostUsed {
                         UNDELETE,
                         UPDATE,
                         UPSERT,
-                        ITERATOR
+                        ITERATOR,
+                        ORDER
                 ));
     }
 

--- a/apex-squid/src/main/java/org/fundacionjala/enforce/sonarqube/apex/api/grammar/buildersource/Type.java
+++ b/apex-squid/src/main/java/org/fundacionjala/enforce/sonarqube/apex/api/grammar/buildersource/Type.java
@@ -42,6 +42,7 @@ public class Type {
                         VIRTUAL,
                         OVERRIDE,
                         TESTMETHOD,
+                        WEBSERVICE,
                         ANNOTATION))
         );
     }

--- a/apex-squid/src/main/java/org/fundacionjala/enforce/sonarqube/apex/lexer/ApexLexer.java
+++ b/apex-squid/src/main/java/org/fundacionjala/enforce/sonarqube/apex/lexer/ApexLexer.java
@@ -26,7 +26,7 @@ public class ApexLexer {
     /**
      * Stores a pattern to identify a keyword.
      */
-    private static final String IDENTIFIER_PATTERN = "(_{0,2}[a-zA-Z][a-zA-Z0-9]*)+";
+    private static final String IDENTIFIER_PATTERN = "(_{0,2}[a-zA-Z][_a-zA-Z0-9]*)+";
 
     /**
      * Stores a pattern to identify a String.

--- a/apex-squid/src/test/java/org/fundacionjala/enforce/sonarqube/apex/parser/grammar/ApexGrammarFieldDeclarationTest.java
+++ b/apex-squid/src/test/java/org/fundacionjala/enforce/sonarqube/apex/parser/grammar/ApexGrammarFieldDeclarationTest.java
@@ -27,6 +27,9 @@ public class ApexGrammarFieldDeclarationTest extends ApexRuleTest {
                 .matches("Boolean isActive = true;")
                 .matches("integer addition = 0;")
                 .matches("ClassType transient;")
+                .matches("Integer count = 0;")
+                .matches("Integer order = 0;")
+                .matches("Product2 product_01 = new Product2();")
                 .matches("Iterator iterator = iteratorParameter;");
     }
 

--- a/apex-squid/src/test/java/org/fundacionjala/enforce/sonarqube/apex/parser/grammar/ApexGrammarTest.java
+++ b/apex-squid/src/test/java/org/fundacionjala/enforce/sonarqube/apex/parser/grammar/ApexGrammarTest.java
@@ -130,6 +130,7 @@ public class ApexGrammarTest extends ApexRuleTest {
                         + "\n"
                         + "Integer count = 0;\n"
                         + "WebService String StagingFacilityType;\n"
+                        + "public static String EscapeSingleQuotes(Iterator<String> iteratorToEscape){}\n"
                         + "String whereFiltersStmt = SecurityUtil.EscapeSingleQuotes(params.get('whereStmtFilters'));\n"
                         + "static testMethod void DateFilterValidationTemplate(){}"
                         + "        protected void aMethod(AType var1, OtherType var2, integer var3);\n"

--- a/apex-squid/src/test/java/org/fundacionjala/enforce/sonarqube/apex/parser/grammar/ApexGrammarTest.java
+++ b/apex-squid/src/test/java/org/fundacionjala/enforce/sonarqube/apex/parser/grammar/ApexGrammarTest.java
@@ -4,7 +4,6 @@
  */
 package org.fundacionjala.enforce.sonarqube.apex.parser.grammar;
 
-
 import org.fundacionjala.enforce.sonarqube.apex.parser.ApexRuleTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -129,6 +128,10 @@ public class ApexGrammarTest extends ApexRuleTest {
                         + "\n"
                         + "    public with sharing interface anInterface implements otherInterface {\n"
                         + "\n"
+                        + "Integer count = 0;\n"
+                        + "WebService String StagingFacilityType;\n"
+                        + "String whereFiltersStmt = SecurityUtil.EscapeSingleQuotes(params.get('whereStmtFilters'));\n"
+                        + "static testMethod void DateFilterValidationTemplate(){}"
                         + "        protected void aMethod(AType var1, OtherType var2, integer var3);\n"
                         + "    }\n"
                         + "\n"
@@ -196,7 +199,7 @@ public class ApexGrammarTest extends ApexRuleTest {
                 StandardCharsets.UTF_8);
         assertThat(parser).matches(fileToString);
     }
-    
+
     @Test
     public void recoveryDeclarationTest() {
         assertThat(parser)


### PR DESCRIPTION
From the reported bugs that showed parsing errors, the following were fixed:
- Count keyword (Added to the allowed keywords)
- 'Product2 product_01 = new Product2();' (Made the identifiers support underscores)
- Order keyword (Added to the allowed keywords)
- Webservice as Modifier
