### PR TITLE
Reparse string soqls

### DIFF
--- a/apex-checks/src/main/java/org/fundacionjala/enforce/sonarqube/apex/checks/soql/SoqlLimitCheck.java
+++ b/apex-checks/src/main/java/org/fundacionjala/enforce/sonarqube/apex/checks/soql/SoqlLimitCheck.java
@@ -4,7 +4,6 @@
  */
 package org.fundacionjala.enforce.sonarqube.apex.checks.soql;
 
-import com.google.common.base.Charsets;
 import org.fundacionjala.enforce.sonarqube.apex.api.grammar.ApexGrammarRuleKey;
 import org.fundacionjala.enforce.sonarqube.apex.checks.ChecksBundle;
 import org.fundacionjala.enforce.sonarqube.apex.checks.ChecksLogger;
@@ -13,10 +12,6 @@ import org.sonar.squidbridge.checks.SquidCheck;
 
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
-import com.sonar.sslr.impl.Parser;
-import org.apache.commons.lang.StringUtils;
-import org.fundacionjala.enforce.sonarqube.apex.ApexConfiguration;
-import org.fundacionjala.enforce.sonarqube.apex.parser.ApexParser;
 
 @Rule(key = SoqlLimitCheck.CHECK_KEY)
 public class SoqlLimitCheck extends SquidCheck<Grammar> {
@@ -45,16 +40,14 @@ public class SoqlLimitCheck extends SquidCheck<Grammar> {
     @Override
     public void visitNode(AstNode astNode) {
         try {
-            if(astNode.is(ApexGrammarRuleKey.STRING_LITERAL_STRING) && astNode.getTokenValue().startsWith("'SELECT")){
-                String string = astNode.getTokenOriginalValue();
-                String queryAsString = StringUtils.substringBetween(string, "'", "'");
-                Parser<Grammar> queryParser = ApexParser.create(new ApexConfiguration(Charsets.UTF_8));
-                queryParser.setRootRule(queryParser.getGrammar().rule(ApexGrammarRuleKey.QUERY_EXPRESSION));
-                AstNode parsedQuery = queryParser.parse(queryAsString);
-                astNode = parsedQuery;
-            }
-            
-            if (!astNode.hasDescendant(ApexGrammarRuleKey.LIMIT_SENTENCE)) {
+            AstNode nodeToCheck = astNode;
+            if(SoqlParser.isStringQuery(astNode)){
+                AstNode parsedQuery = SoqlParser.parseQuery(astNode);
+                if(parsedQuery != null) {
+                    nodeToCheck = parsedQuery;
+                }
+            }          
+            if (!nodeToCheck.hasDescendant(ApexGrammarRuleKey.LIMIT_SENTENCE)) {
                 getContext().createLineViolation(this, MESSAGE, astNode);
             }
         } catch (Exception e) {

--- a/apex-checks/src/main/java/org/fundacionjala/enforce/sonarqube/apex/checks/soql/SoqlParser.java
+++ b/apex-checks/src/main/java/org/fundacionjala/enforce/sonarqube/apex/checks/soql/SoqlParser.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Fundacion Jala. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+package org.fundacionjala.enforce.sonarqube.apex.checks.soql;
+
+import org.apache.commons.lang.StringUtils;
+import org.fundacionjala.enforce.sonarqube.apex.ApexConfiguration;
+import org.fundacionjala.enforce.sonarqube.apex.api.grammar.ApexGrammarRuleKey;
+import org.fundacionjala.enforce.sonarqube.apex.checks.ChecksLogger;
+import org.fundacionjala.enforce.sonarqube.apex.parser.ApexParser;
+
+import com.google.common.base.Charsets;
+import com.sonar.sslr.api.AstNode;
+import com.sonar.sslr.api.Grammar;
+import com.sonar.sslr.impl.Parser;
+
+public class SoqlParser {
+
+    /**
+     * String used to log.
+     */
+    private static final String CLASS_TO_LOG = "SoqlParser";
+
+    /**
+     * String used to log.
+     */
+    private static final String METHOD_TO_LOG = "parseQuery";
+
+    /**
+     * The beginning of a SOQL sentence.
+     */
+    private static final String SOQL_START = "'SELECT";
+
+    /**
+     * Checks if a node is a query by checking if it's a string and then it's
+     * beginning.
+     *
+     * @param astNode The node to check.
+     * @return True if the node is a query as String.
+     */
+    public static boolean isStringQuery(AstNode astNode) {
+        return astNode.is(ApexGrammarRuleKey.STRING_LITERAL_STRING)
+                && astNode.getTokenValue().startsWith(SOQL_START);
+    }
+
+    /**
+     * Re-parses a query that was retrieved as a String.
+     *
+     * @param astNode The String's node.
+     * @return The query as a new QUERY_EXPRESSION node.
+     */
+    public static AstNode parseQuery(AstNode astNode) {
+        AstNode parsedQuery = null;
+        try {
+            String string = astNode.getTokenOriginalValue();
+            String queryAsString = StringUtils.substringBetween(string, "'", "'");
+            Parser<Grammar> queryParser = ApexParser.create(new ApexConfiguration(Charsets.UTF_8));
+            queryParser.setRootRule(queryParser.getGrammar().rule(ApexGrammarRuleKey.QUERY_EXPRESSION));
+            parsedQuery = queryParser.parse(queryAsString);
+        } catch (Exception e) {
+            ChecksLogger.logCheckError(CLASS_TO_LOG, METHOD_TO_LOG, e.toString());
+        }
+        return parsedQuery;
+    }
+}

--- a/apex-checks/src/test/java/org/fundacionjala/enforce/sonarqube/apex/checks/soql/SoqlLimitCheckTest.java
+++ b/apex-checks/src/test/java/org/fundacionjala/enforce/sonarqube/apex/checks/soql/SoqlLimitCheckTest.java
@@ -28,6 +28,7 @@ public class SoqlLimitCheckTest {
         sourceFile = scanFile(new File("src/test/resources/checks/soqlLimit.cls"), check);
         CheckMessagesVerifier.verify(sourceFile.getCheckMessages())
                 .next().atLine(4).withMessage("Define the LIMIT for this SOQL statement.")
+                .next().atLine(5).withMessage("Define the LIMIT for this SOQL statement.")
                 .noMore();
     }
 }

--- a/apex-checks/src/test/resources/checks/soqlLimit.cls
+++ b/apex-checks/src/test/resources/checks/soqlLimit.cls
@@ -2,6 +2,7 @@ public class SomeClass {
 	
 	public static void aMethod() {
             List<table1> incorrect = [SELECT dato FROM table1];
+            List<table1> incorrect = Database.query('SELECT dato FROM table1');
         }
 
         public static void aMethod() {


### PR DESCRIPTION
Soql sentences were only recognized as such when they were in the format "[ _SOQLSentence_ ]" and not as strings, for example Database.query(' _SOQLSentence_ ').

In order to solve this issue, whenever a query was recognized as a String, this need to be re-parsed as a SOQL_EXPRESSION
