### PR TITLE
Enforce SOQL Limit check against QUERY_EXPRESSIONS

### DIFF
--- a/apex-checks/src/main/java/org/fundacionjala/enforce/sonarqube/apex/checks/soql/SoqlLimitCheck.java
+++ b/apex-checks/src/main/java/org/fundacionjala/enforce/sonarqube/apex/checks/soql/SoqlLimitCheck.java
@@ -46,8 +46,9 @@ public class SoqlLimitCheck extends SquidCheck<Grammar> {
                 if(parsedQuery != null) {
                     nodeToCheck = parsedQuery;
                 }
-            }          
-            if (!nodeToCheck.hasDescendant(ApexGrammarRuleKey.LIMIT_SENTENCE)) {
+            }
+
+            if (nodeToCheck.is(ApexGrammarRuleKey.QUERY_EXPRESSION) && !nodeToCheck.hasDescendant(ApexGrammarRuleKey.LIMIT_SENTENCE)) {
                 getContext().createLineViolation(this, MESSAGE, astNode);
             }
         } catch (Exception e) {


### PR DESCRIPTION
The SOQL limit check was going against expressions that weren’t SOQL. This adds a check to ensure the node is a QUERY_EXPRESSION when passed or when re-parsed if it is a string.
