### PR TITLE
Fix parser error when using case as type

### DIFF
--- a/apex-squid/src/main/java/org/fundacionjala/enforce/sonarqube/apex/api/grammar/buildersource/MostUsed.java
+++ b/apex-squid/src/main/java/org/fundacionjala/enforce/sonarqube/apex/api/grammar/buildersource/MostUsed.java
@@ -43,6 +43,7 @@ public class MostUsed {
     private static void allowedKeywordsAsIdentifier(LexerfulGrammarBuilder grammarBuilder) {
         grammarBuilder.rule(ALLOWED_KEYWORDS_AS_IDENTIFIER).is(
                 grammarBuilder.firstOf(
+                        CASE,
                         IDENTIFIER,
                         TRANSIENT,
                         RETURNING,


### PR DESCRIPTION
Using Case as a type was causing a parser error.
