### PR TITLE
Methods as external SOQL vars

### DIFF
--- a/apex-squid/src/main/java/org/fundacionjala/enforce/sonarqube/apex/api/grammar/buildersource/SOQLExpressions.java
+++ b/apex-squid/src/main/java/org/fundacionjala/enforce/sonarqube/apex/api/grammar/buildersource/SOQLExpressions.java
@@ -10,7 +10,6 @@ import static org.fundacionjala.enforce.sonarqube.apex.api.ApexKeyword.AND_SOQL;
 import static org.fundacionjala.enforce.sonarqube.apex.api.ApexKeyword.AS;
 import static org.fundacionjala.enforce.sonarqube.apex.api.ApexKeyword.ASC;
 import static org.fundacionjala.enforce.sonarqube.apex.api.ApexKeyword.BY;
-import static org.fundacionjala.enforce.sonarqube.apex.api.ApexKeyword.CASE;
 import static org.fundacionjala.enforce.sonarqube.apex.api.ApexKeyword.COUNT;
 import static org.fundacionjala.enforce.sonarqube.apex.api.ApexKeyword.CUBE;
 import static org.fundacionjala.enforce.sonarqube.apex.api.ApexKeyword.DES;
@@ -49,6 +48,7 @@ import static org.fundacionjala.enforce.sonarqube.apex.api.ApexTokenType.STRING;
 import static org.fundacionjala.enforce.sonarqube.apex.api.grammar.ApexGrammarRuleKey.ALIASSTATEMENT;
 import static org.fundacionjala.enforce.sonarqube.apex.api.grammar.ApexGrammarRuleKey.ALLOWED_KEYWORDS_AS_SOBJECT_NAME;
 import static org.fundacionjala.enforce.sonarqube.apex.api.grammar.ApexGrammarRuleKey.AND_SOQL_EXPRESSION;
+import static org.fundacionjala.enforce.sonarqube.apex.api.grammar.ApexGrammarRuleKey.ARGUMENTS;
 import static org.fundacionjala.enforce.sonarqube.apex.api.grammar.ApexGrammarRuleKey.CONDITIONAL_SOQL_EXPRESSION;
 import static org.fundacionjala.enforce.sonarqube.apex.api.grammar.ApexGrammarRuleKey.COUNT_EXPR;
 import static org.fundacionjala.enforce.sonarqube.apex.api.grammar.ApexGrammarRuleKey.FIELD;
@@ -91,6 +91,7 @@ public class SOQLExpressions {
         withSentence(grammarBuilder);
         whereSentence(grammarBuilder);
         fieldExpression(grammarBuilder);
+        soqlExternalVariable(grammarBuilder);
         simpleExpression(grammarBuilder);
         filteringExpressions(grammarBuilder);
         operatorToComparisson(grammarBuilder);
@@ -271,10 +272,13 @@ public class SOQLExpressions {
                         STRING,
                         INTEGER_LITERAL,
                         SOQL_EXTERNAL_VARIABLE));
-
-        grammarBuilder.rule(SOQL_EXTERNAL_VARIABLE).is(
+    }
+    
+    private static void soqlExternalVariable(LexerfulGrammarBuilder grammarBuilder){
+    	grammarBuilder.rule(SOQL_EXTERNAL_VARIABLE).is(
                 COLON,
-                NAME);
+                NAME
+                ,grammarBuilder.optional(ARGUMENTS));
     }
 
     /**
@@ -289,11 +293,11 @@ public class SOQLExpressions {
                 grammarBuilder.firstOf(
                         IN,
                         INCLUDES,
-                        EXCLUDES),
-                LPAREN,
-                grammarBuilder.firstOf(SOQL_NAME, QUERY_EXPRESSION),
-                grammarBuilder.zeroOrMore(COMMA, SOQL_NAME),
-                RPAREN
+                        EXCLUDES)
+                ,grammarBuilder.optional(LPAREN)
+                ,grammarBuilder.firstOf(SOQL_NAME, QUERY_EXPRESSION, SOQL_EXTERNAL_VARIABLE)
+                ,grammarBuilder.zeroOrMore(COMMA, SOQL_NAME)
+                ,grammarBuilder.optional(RPAREN)
         );
     }
 

--- a/apex-squid/src/test/java/org/fundacionjala/enforce/sonarqube/apex/parser/grammar/ApexGrammarQueryExpressionTest.java
+++ b/apex-squid/src/test/java/org/fundacionjala/enforce/sonarqube/apex/parser/grammar/ApexGrammarQueryExpressionTest.java
@@ -449,7 +449,10 @@ public class ApexGrammarQueryExpressionTest extends ApexRuleTest {
                         + "FROM Account WHERE industry = :obj.var.media ")
                 .matches("SELECT Name "
                         + "FROM Account WHERE industry = :media AND year = 2016 AND country = :countryId "
-                        + "GROUP BY CUBE (BillingPostalCode,Id) LIMIT 1250");
+                        + "GROUP BY CUBE (BillingPostalCode,Id) LIMIT 1250")
+                .matches("SELECT Id, Name from Case2 WHERE Id in :someMap.keySet()")
+                .matches("SELECT Id, Name from Case WHERE Id in :method(other.keySet())")
+                .matches("select id, name, someOther from Account where name in :functionCall())");
     }
 
     @Test


### PR DESCRIPTION
Allowing arguments on the tail of a name-side of the FilterExpression
handles cases where function-style arguments are used as right-side
operands.